### PR TITLE
Resolve Banner image issue

### DIFF
--- a/src/Banner.js
+++ b/src/Banner.js
@@ -13,7 +13,7 @@ function Banner() {
       const request = await axios.get(requests.fetchNetflixOriginals);
       setMovie(
         request.data.results[
-          Math.floor(Math.random() * request.data.results.length - 1)
+        Math.floor(Math.random() * request.data.results.length - 1)
         ]
       );
       return request;
@@ -36,7 +36,7 @@ function Banner() {
       style={{
         backgroundSize: "cover",
         // `url("https://image.tmdb.org/t/p/original/${movie.backdrop_path}}")`
-        backgroundImage: `url("https://www.moviedb.org/t/p/original/${movie.backdrop_path}})`,
+        backgroundImage: `url("https://www.themoviedb.org/t/p/original/${movie.backdrop_path}")`,
         backgroundPosition: "center center",
       }}
     >


### PR DESCRIPTION
Previous Bug:
Banner Image was not visible and was not able to fetch from the movie db database.

Issue Fix and Solution:
It looks like there might be a syntax error in the URL you're using to fetch the background image from The Movie Database. Specifically, there's an extra closing curly brace (}) at the end of the URL.

Final Output:


![image](https://user-images.githubusercontent.com/75840118/228222797-af60a4e5-6a77-442f-b5fd-3f2715c1713f.png)
